### PR TITLE
Add basic committee-filtering-by-click

### DIFF
--- a/front/src/interfaces.ts
+++ b/front/src/interfaces.ts
@@ -3,7 +3,7 @@ export enum ApplicationStatus {
   TOINTERVIEW = 'to_interview',
   REJECTED = 'rejected',
   ACCEPTED = 'accepted',
-  INREVIEW = 'in_review',
+  INREVIEW = 'in_review'
 }
 
 export enum CommitteeType {
@@ -17,32 +17,37 @@ export enum CommitteeType {
 }
 
 export enum ClassStanding {
-  FRESHMAN = "freshman",
-  SOPHOMORE = "sophomore", 
-  JUNIOR = "junior"
+  FRESHMAN = 'freshman',
+  SOPHOMORE = 'sophomore',
+  JUNIOR = 'junior'
 }
 
-export interface Application {
+export interface ApplicationBase {
   id: string;
-  name: string;
-  email: string;
   year: ClassStanding;
+  name: string;
+  resume_link: string;
+  email: string;
+  committees: { id: number; committee: CommitteeType }[];
+  status: ApplicationStatus;
+  committee_accepted: CommitteeType;
+}
+
+export interface Application extends ApplicationBase {
   director: boolean;
   attendedVH: boolean;
   feedback: string;
-  status: ApplicationStatus;
   source: string;
   essay1: string;
   essay2: string;
   essay3: string;
-  resume_link: string
   github_link: string;
   linkedin_link: string;
   social_link: string | null;
   design_link: string | null;
-  committees: { id: number, committee: CommitteeType }[];
-  committee_accepted: CommitteeType;
 }
+
+export interface ApplicantRow extends ApplicationBase {}
 
 export interface InterviewResponse {
   question: string;
@@ -59,7 +64,7 @@ export interface Note {
   teamwork: string;
   overall: string;
   thoughts: string;
-  responses: InterviewResponse[]
+  responses: InterviewResponse[];
 }
 
 export interface ApplicantResponse {
@@ -73,15 +78,4 @@ export interface ApplicantResponse {
 export interface Comment {
   commenter_name: string;
   content: string;
-}
-
-export interface ApplicantRow {
-  id: Application["id"];
-  year: Application["year"];
-  name: Application["name"];
-  resume: Application["resume_link"];
-  email: Application["email"];
-  committees: Application["committees"];
-  status: Application["status"];
-  committee_accepted: Application["committee_accepted"];
 }

--- a/front/src/interfaces.ts
+++ b/front/src/interfaces.ts
@@ -74,3 +74,14 @@ export interface Comment {
   commenter_name: string;
   content: string;
 }
+
+export interface ApplicantRow {
+  id: Application["id"];
+  year: Application["year"];
+  name: Application["name"];
+  resume: Application["resume_link"];
+  email: Application["email"];
+  committees: Application["committees"];
+  status: Application["status"];
+  committee_accepted: Application["committee_accepted"];
+}

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -14,7 +14,7 @@
   import wretch from 'wretch';
 
   import { API_URL } from '../config/api';
-  import type { Application } from '../interfaces';
+  import type { Application, ApplicantRow } from '../interfaces';
   import { ApplicationStatus, CommitteeType } from '../interfaces';
   import { capitalizeFirstLetter, replaceUnderscores } from '../utils/filters';
   import { authStore } from '../stores/auth.js';
@@ -47,21 +47,7 @@
     },
     { key: 'overflow', empty: true }
   ];
-  interface CommitteeEntity {
-    id: number;
-    committee: CommitteeType;
-  }
-  interface RowEntity {
-    id: number;
-    year: string;
-    name: string;
-    resume: string;
-    email: string;
-    committees: CommitteeEntity[];
-    status: string;
-    committee_accepted: string;
-  }
-  let rows: RowEntity[];
+  let rows: ApplicantRow[];
 
   const colors = {
     operations: 'magenta',
@@ -82,7 +68,7 @@
       .get()
       .json();
     rows = applications.map(application => ({
-      id: parseInt(application.id),
+      id: application.id,
       year: capitalizeFirstLetter(application.year),
       name: application.name,
       resume: application.resume_link,
@@ -97,7 +83,7 @@
   let selectedCommittee;
 
   const passesCommitteeFilters = (
-    rows: RowEntity[],
+    rows: ApplicantRow[],
     selectedCommittee: CommitteeType
   ) => {
     if (!selectedCommittee) {

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -48,20 +48,20 @@
     { key: 'overflow', empty: true }
   ];
   interface CommitteeEntity {
-    id: number,
-    committee: CommitteeType,
+    id: number;
+    committee: CommitteeType;
   }
   interface RowEntity {
-    id: number,
-    year: string,
-    name: string,
-    resume: string,
-    email: string,
-    committees: CommitteeEntity[],
-    status: string,
-    committee_accepted: string
+    id: number;
+    year: string;
+    name: string;
+    resume: string;
+    email: string;
+    committees: CommitteeEntity[];
+    status: string;
+    committee_accepted: string;
   }
-  let rows : RowEntity[];
+  let rows: RowEntity[];
 
   const colors = {
     operations: 'magenta',
@@ -103,11 +103,13 @@
     if (!selectedCommittee) {
       return rows;
     }
-    return rows.filter((row) => {
+    return rows.filter(row => {
       if (row.status == ApplicationStatus.ACCEPTED) {
         return row.committee_accepted == selectedCommittee;
       }
-      return row.committees.some(({ committee }) => committee === selectedCommittee);
+      return row.committees.some(
+        ({ committee }) => committee === selectedCommittee
+      );
     });
   };
 

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -5,7 +5,8 @@
     OverflowMenu,
     OverflowMenuItem,
     DataTableSkeleton,
-    Link
+    Link,
+    Button
   } from 'carbon-components-svelte';
   import Document32 from 'carbon-icons-svelte/lib/Document32';
   import { onMount } from 'svelte';
@@ -118,6 +119,12 @@
         <ToolbarSearch bind:value={searchTerm} />
       </ToolbarContent>
     </Toolbar> -->
+    <Button 
+      kind="secondary" 
+      disabled={selectedCommittee==null ? true : false}
+      on:click={() => updateCommitteeSelection(null)}>
+      Clear committee filter: {selectedCommittee==null ? "none" : selectedCommittee}
+    </Button>
     <span slot="cell-header" let:header>
       {#if header.key === 'committees'}
         {header.value + getCommitteeSelectionText(selectedCommittee)}

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -156,7 +156,7 @@
         {capitalizeFirstLetter(replaceUnderscores(cell.value))}
       {:else if cell.key === 'committees'}
         {#if row.status === ApplicationStatus.ACCEPTED}
-          <Tag 
+          <Tag
             type="green"
             on:click={() => updateCommitteeSelection(row.committee_accepted)}>
             {capitalizeFirstLetter(row.committee_accepted)}

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -14,7 +14,7 @@
 
   import { API_URL } from '../config/api';
   import type { Application } from '../interfaces';
-  import { ApplicationStatus } from '../interfaces';
+  import { ApplicationStatus, CommitteeType } from '../interfaces';
   import { capitalizeFirstLetter, replaceUnderscores } from '../utils/filters';
   import { authStore } from '../stores/auth.js';
   const { token } = authStore;
@@ -78,6 +78,24 @@
     }));
     loading = false;
   });
+
+  let selectedCommittee = null;
+  
+  const passesCommitteeFilters = (rows: any[], selectedCommittee: CommitteeType) => {
+    if (selectedCommittee==null) {return rows;}
+    return rows.filter(function(row) {
+      let commExists = false;
+      row.committees.forEach(function(commObj: { committee: CommitteeType; }) {
+        if (commObj.committee == selectedCommittee) {commExists = true;}
+      });
+      return commExists;
+    });
+  }
+
+  const updateCommitteeSelection = (committee: CommitteeType) => {
+    selectedCommittee = committee;
+    return true;
+  }
 </script>
 
 <svelte:window on:click={click} />
@@ -89,7 +107,12 @@
     sortable
     title="Active Applications: {rows.length}"
     {headers}
-    {rows}>
+    rows={passesCommitteeFilters(rows, selectedCommittee)}>
+    <!-- <Toolbar>
+      <ToolbarContent>
+        <ToolbarSearch bind:value={searchTerm} />
+      </ToolbarContent>
+    </Toolbar> -->
     <span slot="cell" let:row let:cell>
       {#if cell.key === 'resume'}
         <a target="_blank" href={cell.value}>
@@ -113,7 +136,7 @@
           </Tag>
         {:else}
           {#each cell.value as { committee }}
-            <Tag type={colors[committee]}>
+            <Tag type={colors[committee]} on:click={() => updateCommitteeSelection(committee)}>
               {capitalizeFirstLetter(committee)}
             </Tag>
           {/each}

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -156,7 +156,9 @@
         {capitalizeFirstLetter(replaceUnderscores(cell.value))}
       {:else if cell.key === 'committees'}
         {#if row.status === ApplicationStatus.ACCEPTED}
-          <Tag type="green">
+          <Tag 
+            type="green"
+            on:click={() => updateCommitteeSelection(row.committee_accepted)}>
             {capitalizeFirstLetter(row.committee_accepted)}
           </Tag>
         {:else}

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -47,7 +47,21 @@
     },
     { key: 'overflow', empty: true }
   ];
-  let rows = [];
+  interface CommitteeEntity {
+    id: number,
+    committee: CommitteeType,
+  }
+  interface RowEntity {
+    id: number,
+    year: string,
+    name: string,
+    resume: string,
+    email: string,
+    committees: CommitteeEntity[],
+    status: string,
+    committee_accepted: string
+  }
+  let rows : RowEntity[];
 
   const colors = {
     operations: 'magenta',
@@ -68,7 +82,7 @@
       .get()
       .json();
     rows = applications.map(application => ({
-      id: application.id,
+      id: parseInt(application.id),
       year: capitalizeFirstLetter(application.year),
       name: application.name,
       resume: application.resume_link,
@@ -83,7 +97,7 @@
   let selectedCommittee;
 
   const passesCommitteeFilters = (
-    rows: any[],
+    rows: RowEntity[],
     selectedCommittee: CommitteeType
   ) => {
     if (!selectedCommittee) {

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -30,7 +30,7 @@
       value: 'Year'
     },
     {
-      key: 'resume',
+      key: 'resume_link',
       value: 'Résumé'
     },
     {
@@ -71,7 +71,7 @@
       id: application.id,
       year: capitalizeFirstLetter(application.year),
       name: application.name,
-      resume: application.resume_link,
+      resume_link: application.resume_link,
       email: application.email,
       committees: application.committees,
       status: application.status,
@@ -82,7 +82,7 @@
 
   let selectedCommittee;
 
-  const passesCommitteeFilters = (
+  const filterApplicantsForCommittee = (
     rows: ApplicantRow[],
     selectedCommittee: CommitteeType
   ) => {
@@ -117,7 +117,7 @@
     sortable
     title="Active Applications: {rows.length}"
     {headers}
-    rows={passesCommitteeFilters(rows, selectedCommittee)}>
+    rows={filterApplicantsForCommittee(rows, selectedCommittee)}>
     <!-- <Toolbar>
       <ToolbarContent>
         <ToolbarSearch bind:value={searchTerm} />
@@ -136,7 +136,7 @@
       {:else}{header.value}{/if}
     </span>
     <span slot="cell" let:row let:cell>
-      {#if cell.key === 'resume'}
+      {#if cell.key === 'resume_link'}
         <a target="_blank" href={cell.value}>
           <Document32 />
         </a>

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -96,6 +96,11 @@
     selectedCommittee = committee;
     return true;
   }
+
+  const getCommitteeSelectionText = (selectedCommittee: CommitteeType) => {
+    let text = (selectedCommittee!=null) ? selectedCommittee.toString() : "all";
+    return " (" + text + ")";
+  }
 </script>
 
 <svelte:window on:click={click} />
@@ -113,6 +118,11 @@
         <ToolbarSearch bind:value={searchTerm} />
       </ToolbarContent>
     </Toolbar> -->
+    <span slot="cell-header" let:header>
+      {#if header.key === 'committees'}
+        {header.value + getCommitteeSelectionText(selectedCommittee)}
+      {:else}{header.value}{/if}
+    </span>
     <span slot="cell" let:row let:cell>
       {#if cell.key === 'resume'}
         <a target="_blank" href={cell.value}>

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -90,6 +90,9 @@
       return rows;
     }
     return rows.filter(function (row) {
+      if (row.status == ApplicationStatus.ACCEPTED) {
+        return row.committee_accepted == selectedCommittee;
+      }
       let commExists = false;
       row.committees.forEach(function (commObj: { committee: CommitteeType }) {
         if (commObj.committee == selectedCommittee) {

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -80,37 +80,29 @@
     loading = false;
   });
 
-  let selectedCommittee = null;
+  let selectedCommittee;
 
   const passesCommitteeFilters = (
     rows: any[],
     selectedCommittee: CommitteeType
   ) => {
-    if (selectedCommittee == null) {
+    if (!selectedCommittee) {
       return rows;
     }
-    return rows.filter(function (row) {
+    return rows.filter((row) => {
       if (row.status == ApplicationStatus.ACCEPTED) {
         return row.committee_accepted == selectedCommittee;
       }
-      let commExists = false;
-      row.committees.forEach(function (commObj: { committee: CommitteeType }) {
-        if (commObj.committee == selectedCommittee) {
-          commExists = true;
-        }
-      });
-      return commExists;
+      return row.committees.some(({ committee }) => committee === selectedCommittee);
     });
   };
 
   const updateCommitteeSelection = (committee: CommitteeType) => {
     selectedCommittee = committee;
-    return true;
   };
 
-  const getCommitteeSelectionText = (selectedCommittee: CommitteeType) => {
-    let text = selectedCommittee != null ? selectedCommittee.toString() : 'all';
-    return ' (' + text + ')';
+  const resetCommitteeSelection = () => {
+    selectedCommittee = null;
   };
 </script>
 
@@ -131,14 +123,14 @@
     </Toolbar> -->
     <Button
       kind="secondary"
-      disabled={selectedCommittee == null ? true : false}
-      on:click={() => updateCommitteeSelection(null)}>
+      disabled={selectedCommittee === null}
+      on:click={resetCommitteeSelection}>
       Clear committee filter:
-      {selectedCommittee == null ? 'none' : selectedCommittee}
+      {selectedCommittee || 'none'}
     </Button>
     <span slot="cell-header" let:header>
       {#if header.key === 'committees'}
-        {header.value + getCommitteeSelectionText(selectedCommittee)}
+        {header.value + ' (' + (selectedCommittee || 'all') + ')'}
       {:else}{header.value}{/if}
     </span>
     <span slot="cell" let:row let:cell>

--- a/front/src/routes/ApplicantsPage.svelte
+++ b/front/src/routes/ApplicantsPage.svelte
@@ -81,27 +81,34 @@
   });
 
   let selectedCommittee = null;
-  
-  const passesCommitteeFilters = (rows: any[], selectedCommittee: CommitteeType) => {
-    if (selectedCommittee==null) {return rows;}
-    return rows.filter(function(row) {
+
+  const passesCommitteeFilters = (
+    rows: any[],
+    selectedCommittee: CommitteeType
+  ) => {
+    if (selectedCommittee == null) {
+      return rows;
+    }
+    return rows.filter(function (row) {
       let commExists = false;
-      row.committees.forEach(function(commObj: { committee: CommitteeType; }) {
-        if (commObj.committee == selectedCommittee) {commExists = true;}
+      row.committees.forEach(function (commObj: { committee: CommitteeType }) {
+        if (commObj.committee == selectedCommittee) {
+          commExists = true;
+        }
       });
       return commExists;
     });
-  }
+  };
 
   const updateCommitteeSelection = (committee: CommitteeType) => {
     selectedCommittee = committee;
     return true;
-  }
+  };
 
   const getCommitteeSelectionText = (selectedCommittee: CommitteeType) => {
-    let text = (selectedCommittee!=null) ? selectedCommittee.toString() : "all";
-    return " (" + text + ")";
-  }
+    let text = selectedCommittee != null ? selectedCommittee.toString() : 'all';
+    return ' (' + text + ')';
+  };
 </script>
 
 <svelte:window on:click={click} />
@@ -119,11 +126,12 @@
         <ToolbarSearch bind:value={searchTerm} />
       </ToolbarContent>
     </Toolbar> -->
-    <Button 
-      kind="secondary" 
-      disabled={selectedCommittee==null ? true : false}
+    <Button
+      kind="secondary"
+      disabled={selectedCommittee == null ? true : false}
       on:click={() => updateCommitteeSelection(null)}>
-      Clear committee filter: {selectedCommittee==null ? "none" : selectedCommittee}
+      Clear committee filter:
+      {selectedCommittee == null ? 'none' : selectedCommittee}
     </Button>
     <span slot="cell-header" let:header>
       {#if header.key === 'committees'}
@@ -153,7 +161,9 @@
           </Tag>
         {:else}
           {#each cell.value as { committee }}
-            <Tag type={colors[committee]} on:click={() => updateCommitteeSelection(committee)}>
+            <Tag
+              type={colors[committee]}
+              on:click={() => updateCommitteeSelection(committee)}>
               {capitalizeFirstLetter(committee)}
             </Tag>
           {/each}


### PR DESCRIPTION
Preliminary solution for #50

-> my PR offers one way to only view applicants to a specific committee (currently only able to filter for 1 at a time): 
- click on any committee present (any applicant in the 'committee' column) to filter
- continue to click on other committees to change filter, or click button to remove filter

![ezgif com-crop](https://user-images.githubusercontent.com/44736622/105327621-bb43c400-5b94-11eb-8917-34f1a25f169c.gif)

(my first instinct was to use the [DataTables built-in custom-sortability ](https://carbon-svelte.vercel.app/components/DataTable#sortable-with-custom-display-and-sort-methods), which would pass a custom filtering function thru the DataTables header. but, both custom sorting/displaying ability seems to be overwritten (or just ignored) by the use of span "cell" slots already in ./front/src/routes/ApplicantsPage.svelte to add colors/make links/etc., so since those customizations can't be migrated to the Data Tables display option, I abandoned that route)
